### PR TITLE
Notification when syntax parsing fails

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -145,19 +145,19 @@ class FileConverter{
                     return editor.edit(edit => {
                         var parsed: any;                      
                         
-                        if (sourceLanguage === "xml" || sourceLanguage == "tmlanguage"){
-                            parsed = plist.parse(documentText);    
-                        }
-                        if (sourceLanguage === "json" || sourceLanguage == "json-tmlanguage"){
-                            parsed = JSON.parse(documentText);
-                        }
-                        if (sourceLanguage === "yaml" || sourceLanguage == "yaml-tmlanguage"){
-                            parsed = YAML.parse(documentText);
-                        }
-                        
-                        if (parsed === undefined || parsed === ""){
-                            // Display a message?
-                            return;
+                        try {
+                            if (sourceLanguage === "xml" || sourceLanguage == "tmlanguage"){
+                                parsed = plist.parse(documentText);    
+                            }
+                            if (sourceLanguage === "json" || sourceLanguage == "json-tmlanguage"){
+                                parsed = JSON.parse(documentText);
+                            }
+                            if (sourceLanguage === "yaml" || sourceLanguage == "yaml-tmlanguage"){
+                                parsed = YAML.parse(documentText);
+                            }
+                        } catch(err) {
+                            console.log(err);
+                            vscode.window.showErrorMessage(err.toString());
                         }
                         
                         if (destinationLanguage === "json" || destinationLanguage === "json-tmlanguage"){


### PR DESCRIPTION
I think this PR is related to issue #3. 

VSCode will display an error message if parsing the syntax of the given file fails.
Like this:
![errormsg](https://cloud.githubusercontent.com/assets/14190221/23470285/fa7a4a00-fee0-11e6-9c9a-643b35d78401.JPG)
