### PR TITLE
Fix for error reporting in JSON files

### DIFF
--- a/src/jsonTmLanguageDiagnosticProvider.ts
+++ b/src/jsonTmLanguageDiagnosticProvider.ts
@@ -2,13 +2,18 @@ import * as vscode from 'vscode';
 import jsonTmLanguageAnalyser from './jsonTmLanguageAnalyser';
 
 export default class jsonTmLanguageDiagnosticProvider{
+
+    private uuidErrors: vscode.DiagnosticCollection;
+
+    public jsonTmLanguageDiagnosticProvider() {
+        this.uuidErrors = vscode.languages.createDiagnosticCollection("languageErrors");
+    }
+
     public CreateDiagnostics(document : vscode.TextDocument){
         let diagnostics: vscode.Diagnostic[] = [];
-        let uuidErrors = vscode.languages.createDiagnosticCollection("languageErrors");
-
         let analyser = new jsonTmLanguageAnalyser();
-       
         var guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
         try{
             let docContent = analyser.getAnalysis(document);
             // Need to determine a mapping back to the source text for each element        
@@ -49,7 +54,7 @@ export default class jsonTmLanguageDiagnosticProvider{
             }
         }
         
-        uuidErrors.set(document.uri, diagnostics);
+        this.uuidErrors.set(document.uri, diagnostics);
     }
     
     private searchElements(element: any, matchingTitle: string){


### PR DESCRIPTION
Issues #19 and #14 report that syntax errors in JSON files accumulate in the Problems window and are not cleared when the errors are fixed.

The previous code was attempting to create a new, named `DiagnosticCollection`
every time the analysis was run, which VSCode was reporting as an error.
```
DiagnosticCollection with name 'languageErrors' does already exist.
extensionHostProcess.js:735
```
This PR creates one `DiagnosticCollection` per instance of `jsonTmLanguageDiagnosticProvider` and re-uses it for every analysis run.

**Note**: I have only tested this very briefly on Windows so it will require more thorough checking.
Fixes #19