### PR TITLE
Fix test fail

### DIFF
--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -16,10 +16,10 @@ import { TextDocument, workspace, window} from 'vscode';
 const formatFilesPath = path.join(__dirname, '..', '..', 'test', 'testfiles');
 
 const jsonTestFile = path.join(formatFilesPath, 'jsontest.JSON-tmLanguage');
-const jsonResultFile = path.join(formatFilesPath, 'jsontest.tmLanguage');
+const jsonResultFile = 'jsontest.tmLanguage';
 
 const yamlTestFile = path.join(formatFilesPath, 'yamltest.YAML-tmLanguage');
-const yamlResultFile = path.join(formatFilesPath, 'yamltest.tmLanguage');
+const yamlResultFile = 'yamltest.tmLanguage';
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite("File conversion tests Tests", () => {
@@ -31,21 +31,25 @@ suite("File conversion tests Tests", () => {
 		var success : boolean = await fileConverter.convertFileToTml();
 		assert.equal(true, success);
 
-		let resultDoc = workspace.textDocuments.find((doc : TextDocument) => { return doc.fileName == jsonResultFile;});
-		var text = resultDoc.getText();
+		let result = path.join(path.dirname(textDocument.fileName), jsonResultFile);
+		let resultDoc = workspace.textDocuments.find((doc : TextDocument) => 
+			{ return doc.fileName == result;});
+		var text = !!resultDoc ? resultDoc.getText() : "";
 		assert.notEqual(text, "");
 	});
 
 	test('Convert from yaml to tmLanguage', async function() {
-		const textDocument = await workspace.openTextDocument(jsonTestFile);
+		const textDocument = await workspace.openTextDocument(yamlTestFile);
 		const textEditor = await window.showTextDocument(textDocument);
 
 		const fileConverter: FileConverter = new FileConverter();
 		var success : boolean = await fileConverter.convertFileToTml();
 		assert.equal(true, success);
 
-		let resultDoc = workspace.textDocuments.find((doc : TextDocument) => { return doc.fileName == jsonResultFile;});
-		var text = resultDoc.getText();
+		let result = path.join(path.dirname(textDocument.fileName), yamlResultFile);
+		let resultDoc = workspace.textDocuments.find((doc : TextDocument) => 
+			{ return doc.fileName == result;});
+		var text = !!resultDoc ? resultDoc.getText() : "";
 		assert.notEqual(text, "");
 	});
 });


### PR DESCRIPTION
The automated tests were failing for me, with the following message:
```
  1) File conversion tests Tests
base.js:240
       Convert from json to tmLanguage:
     TypeError: Cannot read property 'getText' of undefined
      at Context.<anonymous> (D:\Libraries\vscode-tmlanguage\test\extension.test.ts:35:24)
      at Generator.next (<anonymous>)
      at fulfilled (D:\Libraries\vscode-tmlanguage\out\test\extension.test.js:8:58)
      at <anonymous>
  2) File conversion tests Tests
base.js:240
       Convert from yaml to tmLanguage:
     TypeError: Cannot read property 'getText' of undefined
      at Context.<anonymous> (D:\Libraries\vscode-tmlanguage\test\extension.test.ts:48:24)
      at Generator.next (<anonymous>)
      at fulfilled (D:\Libraries\vscode-tmlanguage\out\test\extension.test.js:8:58)
      at <anonymous>
```
On Windows, formatFilesPath had the drive as upper case (D:\) and textDocument.fileName had lower case (d:\), meaning that workspace.textDocuments.find(...) was returning undefined, causing the test to crash. 

This is probably system dependent, there are a lot of reports of similar things regarding node's paths package.

This PR takes the path from the filename of the base document in the editor, so should be consistent. 